### PR TITLE
Fix fastqc bug when not running trimgalore

### DIFF
--- a/sub-workflows/pre_processing.nf
+++ b/sub-workflows/pre_processing.nf
@@ -14,6 +14,7 @@ workflow pre_processing {
       //
       if (params.runFastQC) {
          FastQC(fastq_files)
+         fastqc_logs = FastQC.out.fastqc_report
       }
       if ( params.runSortMeRNA) {
            rRNA_database = file(params.rRNA_database_manifest)


### PR DESCRIPTION
When disabling trimgalore no fastqc reports were included in multiqc report... Fixed by setting the fastqc_logs after the FastQC step is run on raw data...