### PR TITLE
Develop

### DIFF
--- a/confs/UMCU_hg19_PE.config
+++ b/confs/UMCU_hg19_PE.config
@@ -2,7 +2,7 @@ manifest {
     homePage = 'https://github.com/UMCUGenetics/RNASeq-NF'
     description = 'RNASeq-NF is an NGS analysis pipeline for RNA expression quantification'
     mainScript = 'main.nf'
-    version = '1.0.3'
+    version = '1.0.4'
     nextflowVersion = '20.04.1'
 }
 
@@ -205,8 +205,8 @@ process {
           penv = 'threaded'
           cpus = 6
           memory = '32G'
-          publishDir.path = "${params.out_dir}/Sambamba/Markdup"
-          publishDir.mode = 'copy'
+          //publishDir.path = "${params.out_dir}/Sambamba/Markdup"
+          //publishDir.mode = 'copy'
     }
     withLabel : GATK_4_1_3_0_SplitNCigarReads {
           time = '24h'

--- a/confs/UMCU_hg19_SE.config
+++ b/confs/UMCU_hg19_SE.config
@@ -2,7 +2,7 @@
     homePage = 'https://github.com/UMCUGenetics/RNASeq-NF'
     description = 'RNASeq-NF is an NGS analysis pipeline for RNA expression quantification'
     mainScript = 'main.nf'
-    version = '1.0.3'
+    version = '1.0.4'
     nextflowVersion = '20.04.1'
 }
 
@@ -205,8 +205,8 @@ process {
           penv = 'threaded'
           cpus = 6
           memory = '32G'
-          publishDir.path = "${params.out_dir}/Sambamba/Markdup"
-          publishDir.mode = 'copy'
+          //publishDir.path = "${params.out_dir}/Sambamba/Markdup"
+          //publishDir.mode = 'copy'
     }
     withLabel : GATK_4_1_3_0_SplitNCigarReads {
           time = '24h'

--- a/main.nf
+++ b/main.nf
@@ -196,10 +196,10 @@ workflow {
     }
     // # 2) STAR alignment | Sambamba markdup
     if ( params.runMapping ) {
-        include markdup_mapping from './sub-workflows/mapping_deduplication.nf' params(params)
-        mapped = markdup_mapping( fastqs_processed, genome_gtf )
+        include star_alignment from './sub-workflows/star_alignment.nf' params(params)
+        mapped = star_alignment ( fastqs_processed, genome_gtf )
         star_logs = mapped.logs
-        flagstat_logs = mapped.markdup_flagstat
+        flagstat_logs = mapped.star_flagstat
 
     } else {
         flagstat_logs = Channel.empty()
@@ -242,8 +242,7 @@ workflow {
     if ( params.runGermlineCallingGATK ) {
       if ( params.runMapping ) {
           include gatk_germline_calling from './sub-workflows/gatk_germline_calling.nf' params(params)
-          gatk_germline_calling( run_name, mapped.bam_dedup.map {sample_id, rg_id, bam, bai -> 
-                                                                 [sample_id, bam, bai] }) 
+          gatk_germline_calling( run_name, mapped.bam_sorted ) 
       } else {
             exit 1, "GATK4 requires alignment, markdup step. Please enable runMapping and runMarkDup!"
       }        

--- a/sub-workflows/pre_processing.nf
+++ b/sub-workflows/pre_processing.nf
@@ -14,7 +14,7 @@ workflow pre_processing {
       //
       if (params.runFastQC) {
          FastQC(fastq_files)
-         fastqc_logs = FastQC.out.fastqc_report
+         fastqc_logs = FastQC.out.report
       }
       if ( params.runSortMeRNA) {
            rRNA_database = file(params.rRNA_database_manifest)

--- a/sub-workflows/star_alignment.nf
+++ b/sub-workflows/star_alignment.nf
@@ -1,11 +1,9 @@
-include Markdup from '../NextflowModules/Sambamba/0.7.0/Markdup.nf' params( mem:params.sambambamarkdup.mem )
 include AlignReads from '../NextflowModules/STAR/2.7.3a/AlignReads.nf' params( singleEnd:params.singleEnd, optional:params.options.STAR )   
 include Index from '../NextflowModules/Sambamba/0.7.0/Index.nf' params( params )
 include GenomeGenerate from '../NextflowModules/STAR/2.7.3a/GenomeGenerate.nf' params( params )
 include Flagstat as Flagstat_raw from '../NextflowModules/Sambamba/0.7.0/Flagstat.nf' params( params )
-include Flagstat as Flagstat_markdup from '../NextflowModules/Sambamba/0.7.0/Flagstat.nf' params( params )
 
-workflow markdup_mapping {
+workflow star_alignment {
     take:
       fastq_files
       genome_gtf
@@ -34,15 +32,11 @@ workflow markdup_mapping {
       AlignReads( fastq_files, star_index.collect(), genome_gtf.collect() )
       Index( AlignReads.out.bam_file.map {sample_id, rg_id, bam ->
                                          [sample_id, bam] })
-      Markdup( AlignReads.out.bam_file.join(Index.out))
-      Flagstat_raw( AlignReads.out.bam_file.join(Index.out).map {sample_id, rg_id, bam, bai -> [sample_id, bam, bai] } )      
-      Flagstat_markdup( Markdup.out.map {sample_id, rg_id, bam, bai -> [sample_id, bam, bai] } )
+      Flagstat_raw( AlignReads.out.bam_file.join(Index.out).map {sample_id, rg_id, bam, bai -> 
+						                [sample_id, bam, bai] } )      
 
     emit:
       bam_sorted = AlignReads.out.bam_file.join(Index.out)
       logs = AlignReads.out.log.mix(AlignReads.out.final_log)
-      bam_dedup = Markdup.out
       star_flagstat = Flagstat_raw.out
-      markdup_flagstat = Flagstat_markdup.out
-
 }


### PR DESCRIPTION
- Fixed issue with FastQC not appearing in MultiQC report when TrimGalore is not run.
- Moved Sambamba Markup to gatk_germline_calling sub workflow
- Intermediate bam files are not copied to output directory by default (can be altered in config).