### PR TITLE
Fixed an issue where the edgeR task would fail when there is only 1 sample being run with the pipeline.

### DIFF
--- a/bin/deseq2Normalize.R
+++ b/bin/deseq2Normalize.R
@@ -6,6 +6,7 @@ library("DESeq2")
 args = commandArgs(trailingOnly=TRUE)
 counts_raw <- read.delim(args[1], comment.char="#", row.names = 1)
 cds = as.matrix(counts_raw[,7:ncol(counts_raw)])
+colnames(cds) <- colnames(counts_raw)[7:ncol(counts_raw)]
 #Get column data and set dummy condition
 (colData <- data.frame(row.names=colnames(cds),condition=factor(c(rep("exp", ncol(cds))))))
 #Create DEseq2 dataset

--- a/bin/edgerNormalize.R
+++ b/bin/edgerNormalize.R
@@ -8,7 +8,8 @@ args = commandArgs(trailingOnly=TRUE)
 
 fc.df <- read.delim(args[1], comment.char="#")
 # Normalize 
-counts <- fc.df[,8:ncol(fc.df)]
+counts <- data.frame(fc.df[,8:ncol(fc.df)])
+colnames(counts) <- colnames(fc.df)[8:ncol(fc.df)]
 rownames(counts) <- fc.df$Geneid
 x <- DGEList(counts=counts, genes=fc.df[,c("Geneid","Length")] )
 # RPKM/CPM normalization


### PR DESCRIPTION
There was a bug in the code of edgerNormalize.R that created a error when there was only 1 sample in the featureCounts output.

The line of code below is the problem. The counts variable is a data.frame when there are multiple samples in the featureCounts df.
The counts variable is a vector when there is only 1 sample in the featureCounts output.
`counts <- fc.df[,8:ncol(fc.df)]`

Then the  line of code below tries to assign rows names to the previous output. This is not possible for a vector and would result in an error.
`rownames(counts) <- fc.df$Geneid`

My pull request ensures the output is always a data.frame even with 1 sample.
The counts variable with multiple samples will stay the same with this fix but it will also work for a single sample run.

The error message can be seen below.

> Execution completed unsuccessfully!
> 
> The exit status of the task that caused the workflow execution to fail was: 1.
> 
> The full error message was:
> 
> Error executing process > 'alignment_based_quant:EdgerNormalize (edger_normalize pre_NFpipeline)'
> 
> Caused by:
>   Process `alignment_based_quant:EdgerNormalize (edger_normalize pre_NFpipeline)` terminated with an error exit status (1)
> 
> Command executed:
> 
>   edgerNormalize.R pre_NFpipeline_exon_featureCounts.raw.txt pre_NFpipeline
> 
> Command exit status:
>   1
> 
> Command output:
>   (empty)
> 
> Command error:
>   WARNING: Skipping mount /var/singularity/mnt/session/etc/resolv.conf [files]: /etc/resolv.conf doesn't exist in container
>   Loading required package: limma
>   Error in `rownames<-`(`*tmp*`, value = c(26939L, 29637L, 41461L, 38163L,  : 
>     attempt to set 'rownames' on an object with no dimensions
>   Execution halted

